### PR TITLE
Add css class PageControls to Discussion pagers

### DIFF
--- a/class.gopithemehooks.php
+++ b/class.gopithemehooks.php
@@ -1,0 +1,23 @@
+<?php
+
+class GopiThemeHooks implements Gdn_IPlugin {
+    /**
+     * Setup is executed when theme is activated.
+     *
+     * @return void.
+     */
+    public function setup() {
+    }
+
+    /**
+     * Adds class PageControls to discussion pagers.
+     *
+     * @param DiscussionController $sender Instance of the calling class.
+     * @param mixed                $args   Event arguments.
+     *
+     * @return void.
+     */
+    public function discussionController_afterBuildPager_handler($sender, $args) {
+        $args['Pager']->CssClass .= ' PageControls';
+    }
+}


### PR DESCRIPTION
If your discussion has more than one page you see a pager but it isn't styled completely:

![pager](https://cloud.githubusercontent.com/assets/3996187/22144318/92067870-defd-11e6-9b38-c6f110dcf544.jpg)

I gave #PagerBefore and #PagerAfter "manually" the class ".PageControls" and that seemed to fix it.
So I've created a themehooks file that adds this class automatically